### PR TITLE
mapのAPIを追加

### DIFF
--- a/mushi-map-world/package-lock.json
+++ b/mushi-map-world/package-lock.json
@@ -13,6 +13,7 @@
         "@angular/compiler": "~13.0.0",
         "@angular/core": "~13.0.0",
         "@angular/forms": "~13.0.0",
+        "@angular/google-maps": "^13.1.0",
         "@angular/platform-browser": "~13.0.0",
         "@angular/platform-browser-dynamic": "~13.0.0",
         "@angular/router": "~13.0.0",
@@ -463,6 +464,20 @@
         "@angular/common": "13.0.3",
         "@angular/core": "13.0.3",
         "@angular/platform-browser": "13.0.3",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/google-maps": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@angular/google-maps/-/google-maps-13.1.0.tgz",
+      "integrity": "sha512-UeUjdBO/sbKfB3TQbzaZiJnyNjJRLuDTIKno2r7U//xqYyhtKr+pCptvl7sHFjbsum3dlo/Q5ddDQ50EhqRiMw==",
+      "dependencies": {
+        "@types/google.maps": "^3.45.6",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^13.0.0 || ^14.0.0-0",
+        "@angular/core": "^13.0.0 || ^14.0.0-0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -2546,6 +2561,11 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
       "dev": true
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.47.1.tgz",
+      "integrity": "sha512-GNB4VH8fItMk1juxLfJmAAQ97rzBnxHCUc2x+UjN5lpiHMEdJuJK4Bmcv7PMefwIUNajnOXpHjkS+Q6TOQo+VQ=="
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.7",
@@ -12778,6 +12798,15 @@
         "tslib": "^2.3.0"
       }
     },
+    "@angular/google-maps": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@angular/google-maps/-/google-maps-13.1.0.tgz",
+      "integrity": "sha512-UeUjdBO/sbKfB3TQbzaZiJnyNjJRLuDTIKno2r7U//xqYyhtKr+pCptvl7sHFjbsum3dlo/Q5ddDQ50EhqRiMw==",
+      "requires": {
+        "@types/google.maps": "^3.45.6",
+        "tslib": "^2.3.0"
+      }
+    },
     "@angular/platform-browser": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-13.0.3.tgz",
@@ -14279,6 +14308,11 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
       "dev": true
+    },
+    "@types/google.maps": {
+      "version": "3.47.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.47.1.tgz",
+      "integrity": "sha512-GNB4VH8fItMk1juxLfJmAAQ97rzBnxHCUc2x+UjN5lpiHMEdJuJK4Bmcv7PMefwIUNajnOXpHjkS+Q6TOQo+VQ=="
     },
     "@types/http-proxy": {
       "version": "1.17.7",

--- a/mushi-map-world/package.json
+++ b/mushi-map-world/package.json
@@ -15,6 +15,7 @@
     "@angular/compiler": "~13.0.0",
     "@angular/core": "~13.0.0",
     "@angular/forms": "~13.0.0",
+    "@angular/google-maps": "^13.1.0",
     "@angular/platform-browser": "~13.0.0",
     "@angular/platform-browser-dynamic": "~13.0.0",
     "@angular/router": "~13.0.0",

--- a/mushi-map-world/src/app/app.component.html
+++ b/mushi-map-world/src/app/app.component.html
@@ -8,4 +8,4 @@
     </div>
 </div></div>
  -->
-<app-spot></app-spot>
+<app-home></app-home>

--- a/mushi-map-world/src/app/app.module.ts
+++ b/mushi-map-world/src/app/app.module.ts
@@ -2,6 +2,8 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { AppRoutingModule } from './app-routing.module';
+import { GoogleMapsModule } from '@angular/google-maps';
+
 import { AppComponent } from './app.component';
 import { DetailComponent } from './pages/detail/detail.component';
 import { SpotComponent } from './pages/spot/spot.component';
@@ -26,6 +28,7 @@ import { CompleteComponent } from './pages/complete/complete.component';
   imports: [
     BrowserModule,
     AppRoutingModule,
+    GoogleMapsModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/mushi-map-world/src/app/pages/home/home.component.html
+++ b/mushi-map-world/src/app/pages/home/home.component.html
@@ -14,11 +14,20 @@
         <hr>
     </div>
 
-        <div class="frame2">
-            <button class="button0" type="button"><img class="location" src="../../../assets/image/locationforhome.png"></button>
-            <button class="button0" type="button"><img class="addition" src="../../../assets/image/additionforhome.png"></button>
+    <!-- <google-map
+    height="500px"
+    width="500px"
+    [center]="center"
+    [zoom]="zoom"
+    [options]="options"
+    ></google-map> -->
 
-        </div>
+
+    <div class="frame2">
+        <button class="button0" type="button"><img class="location" src="../../../assets/image/locationforhome.png"></button>
+        <button class="button0" type="button"><img class="addition" src="../../../assets/image/additionforhome.png"></button>
+
+    </div>
 
 </div>
 

--- a/mushi-map-world/src/app/pages/home/home.component.ts
+++ b/mushi-map-world/src/app/pages/home/home.component.ts
@@ -7,6 +7,17 @@ import { Component, OnInit } from '@angular/core';
 })
 export class HomeComponent implements OnInit {
 
+  zoom = 16;
+  // 東新宿駅の座標
+  center: google.maps.LatLngLiteral = {
+    lat: 35.697695,
+    lng: 139.707354
+  };
+  // 地図のオプション
+  options: google.maps.MapOptions = {
+    disableDefaultUI: true
+  };
+
   constructor() { }
 
   ngOnInit(): void {

--- a/mushi-map-world/src/index.html
+++ b/mushi-map-world/src/index.html
@@ -6,6 +6,9 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <!-- <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDyoXnwToyq4lvKayw2UFXEWjc5FQjV_Bo"
+    type="text/javascript">
+  </script> -->
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
AngularMaterialのgoogle-mapsをインストール
app.moduleにインポート
index.htmlでAPIキーと接続
Home.htmlでGoogleMapの表示
  使用回数に制限があるため、一時的に切っている